### PR TITLE
Added support for emojis in keyboard

### DIFF
--- a/app/src/main/res/layout/fragment_general.xml
+++ b/app/src/main/res/layout/fragment_general.xml
@@ -52,7 +52,7 @@
                 android:layout_weight="1"
                 android:background="@android:color/transparent"
                 android:hint="@string/enter_message"
-                android:inputType="text"
+                android:inputType="textShortMessage"
                 android:maxLines="6" />
 
             <Button


### PR DESCRIPTION
Changing the input type for `editText` does the job as because adding libraries or creating a `button` will be more complex.